### PR TITLE
Incorporate nursing mortality

### DIFF
--- a/MGDrivE/R/Patch-Simulation.R
+++ b/MGDrivE/R/Patch-Simulation.R
@@ -277,7 +277,7 @@ oneDay_adoDM_stochastic_Patch <- function(){
 #' Deterministic Larva Death and Maturation
 #'
 #' Calculate the number of nursing pups surviving from day to day, given by:
-#' \deqn{\overline{L_{[t-1]}} * {1-\mu_{aq}}
+#' \deqn{\overline{L_{[t-1]}} * {1-\mu_N}}
 #' See \code{\link{parameterizeMGDrivE}} for how these parameters are derived.
 #' Maturation has no parameters, so the final day of nursing pups naturally enter the adolescent state.
 #'
@@ -285,11 +285,11 @@ oneDay_nursingDM_deterministic_Patch <- function(){
   nGeno <- private$NetworkPointer$get_genotypesN()
   nursingStart <- private$NetworkPointer$get_timeJu(stage = 'G') + 1
   nursingEnd <- private$NetworkPointer$get_timeJu(stage = 'G') + private$NetworkPointer$get_timeJu(stage = 'N')
-
+  surv <- 1 - private$NetworkPointer$get_muN()
 
   # run loop backwards to move populations as we go
   for(i in nursingEnd:nursingStart){
-    private$popJuvenile[ ,i+1] = private$popJuvenile[ ,i]
+    private$popJuvenile[ ,i+1] = private$popJuvenile[ ,i] * surv
   } # end loop
 
 }
@@ -297,7 +297,7 @@ oneDay_nursingDM_deterministic_Patch <- function(){
 #' Stochastic Larva Death and Maturation
 #'
 #' The daily number of nursing pups surviving is drawn from a binomial distribution, where
-#' survival probability is given by \deqn{1-\mu_{aq}}
+#' survival probability is given by \deqn{1-\mu_N}
 #' See \code{\link{parameterizeMGDrivE}} for how these parameters are derived.
 #' Maturation has no parameters, so the final day of nursing pups naturally enter the adolescent state.
 #'
@@ -307,13 +307,13 @@ oneDay_nursingDM_stochastic_Patch <- function(){
   nGeno <- private$NetworkPointer$get_genotypesN()
   nursingStart <- private$NetworkPointer$get_timeJu(stage = 'G') + 1
   nursingEnd <- private$NetworkPointer$get_timeJu(stage = 'G') + private$NetworkPointer$get_timeJu(stage = 'N')
-
+  surv <- 1 - private$NetworkPointer$get_muN()
 
   # run loop backwards to move populations as we go
   for(i in nursingEnd:nursingStart){
     private$popJuvenile[ ,i+1] = rbinom(n = nGeno,
                                        size = private$popJuvenile[ ,i],
-                                       prob = 1)
+                                       prob = surv)
   } # end loop
 
 }

--- a/MGDrivE/man/oneDay_nursingDM_deterministic_Patch.Rd
+++ b/MGDrivE/man/oneDay_nursingDM_deterministic_Patch.Rd
@@ -7,5 +7,8 @@
 oneDay_nursingDM_deterministic_Patch()
 }
 \description{
-
+Calculate the number of nursing pups surviving from day to day, given by:
+\deqn{\overline{L_{[t-1]}} * {1-\mu_N}}
+See \code{\link{parameterizeMGDrivE}} for how these parameters are derived.
+Maturation has no parameters, so the final day of nursing pups naturally enter the adolescent state.
 }

--- a/MGDrivE/man/oneDay_nursingDM_stochastic_Patch.Rd
+++ b/MGDrivE/man/oneDay_nursingDM_stochastic_Patch.Rd
@@ -8,7 +8,7 @@ oneDay_nursingDM_stochastic_Patch()
 }
 \description{
 The daily number of nursing pups surviving is drawn from a binomial distribution, where
-survival probability is given by \deqn{1-\mu_{aq}}
+survival probability is given by \deqn{1-\mu_N}
 See \code{\link{parameterizeMGDrivE}} for how these parameters are derived.
 Maturation has no parameters, so the final day of nursing pups naturally enter the adolescent state.
 }


### PR DESCRIPTION
## Summary
- scale deterministic nursing transitions by 1 - muN
- use binomial sampling with 1 - muN survival in stochastic nursing dynamics
- document nursing mortality using muN parameter

## Testing
- `R -q -e "roxygen2::roxygenise()"` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b63e1e988327b8a20369c07e7e9b